### PR TITLE
🐳(labels) dockerize project tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:11.6
+
+WORKDIR /app
+
+# Build the app
+COPY package.json yarn.lock /app/
+RUN yarn install
+
+# Copy configuration files
+COPY github /app/github

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+default: help
+
+build: ## build docker image
+	docker build . -t "fun-config:latest"
+.PHONY: build
+
+help: ## display this message
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+.PHONY: help

--- a/README.md
+++ b/README.md
@@ -32,36 +32,23 @@ export GITHUB_LABELS_TOKEN="thisismytoken"
 Load a new shell or source your rc file to take into account this new
 environment variable (_e.g._ `source $HOME/.zshrc`).
 
-#### Install the `labels` tool
-
-Make sure [Yarn](https://yarnpkg.com) is installed on your machine, then, at the
-root of this repository, install `labels`:
+#### Build the `fun-config` Docker image
 
 ```bash
-$ cd path/to/fun-config
-$ yarn install
+$ make build
 ```
 
 ### Create default labels for a repository
 
-Once `labels` is installed, you can use our default labels configuration to
-initialize labels from a repository:
+Once the `fun-config` image has been successfully built, you can use our default
+labels configuration to initialize labels from a repository:
 
 ```bash
-$ yarn labels -c github/labels/default.json [-f] -t $GITHUB_LABELS_TOKEN user/repository
+$ bin/labels user/repository
 ```
 
 Feel free to substitute `user` by the project namespace (_e.g._ your user name
 or team) and repository by the name of the repository.
-
-> Please note that the `-f` option will erase all project labels before creating
-> the new ones. It must be used with caution.
-
-Example:
-
-```
-$ yarn labels -c github/labels/default.json -t $GITHUB_LABELS_TOKEN openfun/fun-config
-```
 
 ## License
 

--- a/bin/labels
+++ b/bin/labels
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+repository=${1:-}
+
+docker run --rm fun-config:latest \
+    yarn labels -f -c github/labels/default.json -t ${GITHUB_LABELS_TOKEN} ${repository}


### PR DESCRIPTION
## Purpose

Switch the project to a docker-based tool.

## Proposal

- [x] Add a base `Dockerfile`
- [x] Add a `Makefile` to ease build
- [x] Add a `bin/labels` shortcuts that uses the project's docker image
- [x] Update documentation
