### PR TITLE
🔧(labels) add missing WIP label

### DIFF
--- a/github/labels/default.json
+++ b/github/labels/default.json
@@ -46,5 +46,9 @@
   {
     "name": "FUN",
     "color": "006b75"
+  },
+  {
+    "name": "WIP",
+    "color": "ed7f10"
   }
 ]


### PR DESCRIPTION
## Proposal

As suggested by @lunika, we've added the `WIP` label for some repositories. Now it's time to add it as a default label that should be used when initializing a project.
