### PR TITLE
🔧(labels) add missing 'release' label

### DIFF
--- a/bin/labels
+++ b/bin/labels
@@ -2,5 +2,5 @@
 
 repository=${1:-}
 
-docker run --rm fun-config:latest \
+docker run --rm -v $PWD/github:/app/github fun-config:latest \
     yarn labels -f -c github/labels/default.json -t ${GITHUB_LABELS_TOKEN} ${repository}

--- a/github/labels/default.json
+++ b/github/labels/default.json
@@ -48,6 +48,10 @@
     "color": "006b75"
   },
   {
+    "name": "release",
+    "color": "196811"
+  },
+  {
     "name": "WIP",
     "color": "ed7f10"
   }


### PR DESCRIPTION
## Purpose

When submitting a PR for a release, there is no real label that fits with this purpose.

## Proposal

- [x] add the `release` label with `FUN` label color

Fixes #5 