### PR TITLE
♻️(labels) rename "FUN" label to more explicit "FUN Team"

### DIFF
--- a/github/labels/default.json
+++ b/github/labels/default.json
@@ -44,7 +44,7 @@
     "color": "cccccc"
   },
   {
-    "name": "FUN",
+    "name": "FUN Team",
     "color": "006b75"
   },
   {


### PR DESCRIPTION
### Purpose

The "FUN" label is meant to signify the labelled task needs to be undertaken by a member of the FUN team. This was not explicit in the name.

### Proposal

"FUN Team" should better convey this information.