### PR TITLE
🐛(dependencies) replace github-labels with github-label-sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.6
+FROM node:12
 
 WORKDIR /app
 

--- a/bin/labels
+++ b/bin/labels
@@ -3,4 +3,4 @@
 repository=${1:-}
 
 docker run --rm -v $PWD/github:/app/github fun-config:latest \
-    yarn labels -f -c github/labels/default.json -t ${GITHUB_LABELS_TOKEN} ${repository}
+    yarn github-label-sync -l github/labels/default.json -a "${GITHUB_LABELS_TOKEN}" "${repository}"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "GIP FUN Mooc <fun.dev@fun-mooc.fr>",
   "license": "MIT",
   "dependencies": {
-    "github-labels": "^0.8.0"
+    "github-label-sync": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Purpose

The library `github-labels` that is used to update github labels seems
to be broken, because of an authentication issue. 

## Proposal

Replace `github-labels` with [github-label-sync](https://www.npmjs.com/package/github-label-sync), which seems to be a good working and maintained replacement candidate.